### PR TITLE
Documentation overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,27 +27,11 @@ new CopyWebpackPlugin([
 ]);
 ```
 
-Or if you're using Angular CLI:
+Or if you're using the Angular CLI, make sure to include `mdi.svg` in your `assets`
+folder under the [Angular workspace configuration file](https://angular.io/guide/workspace-config)
+in the `assets` array, located in the build configuration for your project:
 
-* For Angular CLI version 1.x, make sure to include `mdi.svg` in your `assets` folder under `.angular-cli.json` in the `assets` array:
-
-   ```json Angular CLI file
-   {
-      "apps": [
-        {
-          "assets": [
-            { "glob": "**/*", "input": "./assets/", "output": "./assets/" },
-            { "glob": "favicon.ico", "input": "./", "output": "./" },
-            { "glob": "mdi.svg", "input": "../node_modules/@mdi/angular-material", "output": "./assets" }
-          ]
-        }
-      ]
-   }
-   ```
-
-* For Angular CLI version 6.x, make sure to include `mdi.svg` in your `assets` folder under `angular.json` in the `assets` array, located in the build configuration for your project:
-
-    ```json Angular CLI file
+    ```json Angular workspace configuration file
     {
        // ...
        "architect": {
@@ -56,7 +40,7 @@ Or if you're using Angular CLI:
              "assets": [
                { "glob": "**/*", "input": "./assets/", "output": "./assets/" },
                { "glob": "favicon.ico", "input": "./", "output": "./" },
-               { "glob": "mdi.svg", "input": "../node_modules/@mdi/angular-material", "output": "./assets" }
+               { "glob": "mdi.svg", "input": "./node_modules/@mdi/angular-material", "output": "./assets" }
              ]
            }
          }
@@ -65,14 +49,22 @@ Or if you're using Angular CLI:
     }
     ```
 
-_Note: To check your version of Angular CLI, run `ng -v` or `$(npm bin)/ng -v`._
+Note that the input directory is dependent on the workspace root which can be found
+by looking at your desired project's `root` property. (For more information, visit the
+Angular documentation on [project configuration options](https://angular.io/guide/workspace-config#project-configuration-options).)
 
-### Angular
+Additionally, see the Angular documentation on [assets configuration](https://angular.io/guide/workspace-config#assets-configuration)
+for more information.
 
-The `mdi.svg` contains all the icons provided on the site. Use inline with [MatIconRegistry](https://material.angular.io/components/icon/api#MatIconRegistry).
+Note: Documentation for Angular CLI versions 1.x.x (around Angular v5) has been dropped
+as Angular v5 is [no longer supported](https://angular.io/guide/releases#support-policy-and-schedule).
 
-1. Place the SVG file under your `assets` folder thanks to Angular CLI or thanks to `CopyWebpackPlugin`. Please ensure that this file is publicly accessible.
-2. In your app's main module (typically `app.module.ts`), import `MatIconModule` and `MatIconRegistry` from `@angular/material`:
+### Angular Material
+
+The `mdi.svg` contains all the icons provided on the site. It can be used inline with
+[MatIconRegistry](https://material.angular.io/components/icon/api#MatIconRegistry).
+
+1. In your app's main module (typically `app.module.ts`), import `MatIconModule` and `MatIconRegistry` from `@angular/material/icon`:
 
 ```typescript App module
 
@@ -97,49 +89,23 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class AppModule {
   constructor(matIconRegistry: MatIconRegistry, domSanitizer: DomSanitizer){
-    matIconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl('./assets/mdi.svg')); // Or whatever path you placed mdi.svg at
+    matIconRegistry.addSvgIconSet(
+      domSanitizer.bypassSecurityTrustResourceUrl('./assets/mdi.svg')
+    );
   }
 }
 ```
 
-Usage:
+2. The SVG icons can then be used with [`MatIcon`](https://material.angular.io/components/icon/api#MatIcon)'s
+`svgIcon` attribute as shown below:
 
 ```html Example Usage
-
-<!-- Icon by itself -->
-<mat-icon svgIcon="android" aria-label="Android icon"></mat-icon>
-<!-- Icon button -->
-<a mat-icon-button href="https://android.com" matTooltip="Go to Android.com" aria-label="Go to Android.com">
-  <mat-icon svgIcon="android" aria-label="Android icon"></mat-icon>
-</button>
-<!-- You can also combine an icon and text together -->
-<button mat-button>
-  <mat-icon svgIcon="code-tags" aria-label="Code icon"></mat-icon>
-  View source
-</button>
-
+<mat-icon svgIcon="<name of icon>"></mat-icon>
 ```
 
-Please also add the following class to your styles (`styles.css`) to solve the problem where an icon isn't aligned properly when used in a menu item:
+For more information about SVG icons, check out the [documentation](https://material.angular.io/components/icon/overview#svg-icons).
 
-```css styles.css
-
-button.mat-menu-item {
-  line-height: 24px !important;
-}
-a.mat-menu-item > mat-icon {
-  margin-bottom: 14px;
-}
-.mat-icon svg {
-  height: 24px;
-  width: 24px;
-}
-
-```
-
-[Stackblitz](https://stackblitz.com/edit/mdi-material-example)
-
-For more information on icons, refer to the [icon docs](https://material.angular.io/components/icon/overview).
+[StackBlitz demo](https://stackblitz.com/edit/mdi-material-example)
 
 ### AngularJS Material
 


### PR DESCRIPTION
- Attempted to impose a max character per line limit on new sections
- Removed outdated documentation on Angular CLI v1.x.x (it was supposed to be used for Angular v5 which is no longer supported)
- Included notes on additional documentation regarding asset configuration with caveats
- Shorten Angular Material section
  - Removed section on aligning issue (seems to have been resolved)
  - Shortened component template usage example

Closes #7 (and other issues I can't think of at the moment)

(CC @Templarian and @darpankumar)