### PR TITLE
Rewrite to use @mdi/util

### DIFF
--- a/build.js
+++ b/build.js
@@ -8,48 +8,15 @@
 //   </defs>
 // </svg>
 
-// TODO: Rewrite with @mdi/util
-const fs = require('fs');
-const svgPackageFolder = "./node_modules/@mdi/svg";
-const encoding = "utf8";
+const { getVersion, write, getMeta } = require('@mdi/util');
 const outputFile = "mdi.svg";
-
-function getVersion() {
-  const file = fs.readFileSync(`${svgPackageFolder}/package.json`, { encoding });
-  return JSON.parse(file).version;
-}
-
-function getSvgFiles() {
-  return fs.readdirSync(`${svgPackageFolder}/svg`).map(file => {
-    return `${svgPackageFolder}/svg/${file}`;
-  })
-}
-
-function getIconData(files) {
-  // { name: "icon-name", path: "M..." }
-  return files.map(file => {
-    const name = file.match(/([^\/]+)\.svg$/)[1];
-    const svgContent = fs.readFileSync(file, { encoding });
-    const viewBox = svgContent.match(/ viewBox="([^"]+)"/)[1];
-    const path = svgContent.match(/ d="([^"]+)"/)[1];
-    return { name, viewBox, path };
-  })
-}
-
-function writeFile(name, data) {
-  fs.writeFileSync(`./${name}`, data, { encoding });
-}
 
 function build() {
   const version = getVersion();
-  const files = getSvgFiles();
-  const icons = getIconData(files);
-  const items = icons.map(({name, viewBox, path}) => {
-    return `<svg id="${name}" viewBox="${viewBox}"><path d="${path}"/></svg>`
-  });
+  const items = getMeta(true).map(({name, path}) => `<svg id="${name}" viewBox="0 0 24 24"><path d="${path}"/></svg>`);
   const template = `<svg><defs>${items.join('')}</defs></svg>`;
-  writeFile(outputFile, template);
-  console.log(`Successfully built v${version}!`);
+  write(outputFile, template);
+  console.log(`MDI: Successfully built v${version}!`);
 }
 
 build();


### PR DESCRIPTION
Hard codes the viewport. So far it is always this value. Source:
```sh
$ cat node_modules/@mdi/svg/svg/*.svg | grep -oE 'viewBox="([^"]+)"' | sort | uniq -c
   7447 viewBox="0 0 24 24"
```